### PR TITLE
Support pagination when fetching IAM users. #12

### DIFF
--- a/cloud/aws/mocks_test.go
+++ b/cloud/aws/mocks_test.go
@@ -79,6 +79,11 @@ func (m *mockIam) ListUsers(input *iam.ListUsersInput) (*iam.ListUsersOutput, er
 	return &iam.ListUsersOutput{Users: m.users}, nil
 }
 
+func (m *mockIam) ListUsersPages(input *iam.ListUsersInput, fn func(p *iam.ListUsersOutput, lastPage bool) (shouldContinue bool)) error {
+	fn(&iam.ListUsersOutput{Users: m.users}, true)
+	return nil
+}
+
 func (m *mockIam) ListPolicies(input *iam.ListPoliciesInput) (*iam.ListPoliciesOutput, error) {
 	var policies []*iam.Policy
 	for _, p := range m.managedPolicies {


### PR DESCRIPTION
Added pagination support for fetching users via `ListUsersPages` (partially addressing #12), and a mocked version of `ListUsersPages` as well. The mocked call only returns a single page so should likely be fleshed out a bit better (whether part of this PR or a separate one).