### PR TITLE
Support pagination for IAM policies

### DIFF
--- a/aws/mocks_test.go
+++ b/aws/mocks_test.go
@@ -112,6 +112,16 @@ func (m *mockIam) ListPolicies(input *iam.ListPoliciesInput) (*iam.ListPoliciesO
 	return &iam.ListPoliciesOutput{Policies: policies}, nil
 }
 
+func (m *mockIam) ListPoliciesPages(input *iam.ListPoliciesInput, fn func(p *iam.ListPoliciesOutput, lastPage bool) (shouldContinue bool)) error {
+	var policies []*iam.Policy
+	for _, p := range m.managedPolicies {
+		policy := &iam.Policy{PolicyId: p.PolicyId, PolicyName: p.PolicyName}
+		policies = append(policies, policy)
+	}
+	fn(&iam.ListPoliciesOutput{Policies: policies}, true)
+	return nil
+}
+
 func (m *mockIam) GetAccountAuthorizationDetails(input *iam.GetAccountAuthorizationDetailsInput) (*iam.GetAccountAuthorizationDetailsOutput, error) {
 	return &iam.GetAccountAuthorizationDetailsOutput{GroupDetailList: m.groups, Policies: m.managedPolicies, RoleDetailList: m.roles, UserDetailList: m.usersDetails}, nil
 }

--- a/gen/aws/fetchers_definitions.go
+++ b/gen/aws/fetchers_definitions.go
@@ -59,7 +59,7 @@ var FetchersDefs = []fetchersDef{
 			{ResourceType: graph.User.String(), AWSType: "iam.UserDetail", ManualFetcher: true},
 			{ResourceType: graph.Group.String(), AWSType: "iam.GroupDetail", ApiMethod: "GetAccountAuthorizationDetails", Input: "iam.GetAccountAuthorizationDetailsInput{Filter: []*string{awssdk.String(iam.EntityTypeGroup)}}", Output: "iam.GetAccountAuthorizationDetailsOutput", OutputsExtractor: "GroupDetailList"},
 			{ResourceType: graph.Role.String(), AWSType: "iam.RoleDetail", ApiMethod: "GetAccountAuthorizationDetails", Input: "iam.GetAccountAuthorizationDetailsInput{Filter: []*string{awssdk.String(iam.EntityTypeRole)}}", Output: "iam.GetAccountAuthorizationDetailsOutput", OutputsExtractor: "RoleDetailList"},
-			{ResourceType: graph.Policy.String(), AWSType: "iam.Policy", ApiMethod: "ListPolicies", Input: "iam.ListPoliciesInput{OnlyAttached: awssdk.Bool(true)}", Output: "iam.ListPoliciesOutput", OutputsExtractor: "Policies"},
+			{ResourceType: graph.Policy.String(), AWSType: "iam.Policy", ApiMethod: "ListPoliciesPages", Input: "iam.ListPoliciesInput{OnlyAttached: awssdk.Bool(true)}", Output: "iam.ListPoliciesOutput", OutputsExtractor: "Policies", Multipage: true, NextPageMarker: "Marker"},
 		},
 	},
 	{


### PR DESCRIPTION
@fxaguessy I saw that you've added pagination support for some services, and I added pagination to the manual fetch logic for IAM users as part of #62. For my use case, I still run into some problems unless I also add pagination support for IAM policies. I've added a fix that resolves issues on my end, and I'm opening this PR for the sake of discussion. We can talk through it if you're interested. If not, feel free to make your own tweaks or close this PR if you've already got ideas in the works. Thanks!

-----

Since the policy-fetching logic is generated Go code, update the IAM
service definition to flag Policies as a multipage resource.

Also update the fetching logic template to always attempt to continue
fetching pages. That offloads checking for truncation tokens to the
underlying SDK, as opposed to explicitly considering whether the target
API uses NextToken, Marker, etc.