### PR TITLE
Support ssh agent

### DIFF
--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -39,6 +39,7 @@ import (
 )
 
 var keyPathFlag string
+var useAgentFlag bool
 var printSSHConfigFlag bool
 var printSSHCLIFlag bool
 var privateIPFlag bool
@@ -47,6 +48,7 @@ var disableStrictHostKeyCheckingFlag bool
 func init() {
 	RootCmd.AddCommand(sshCmd)
 	sshCmd.Flags().StringVarP(&keyPathFlag, "identity", "i", "", "Set path or name toward the identity (key file) to use to connect through SSH")
+	sshCmd.Flags().BoolVarP(&useAgentFlag, "agent", "a", false, "Force using SSH agent")
 	sshCmd.Flags().BoolVar(&printSSHConfigFlag, "print-config", false, "Print SSH configuration for ~/.ssh/config file.")
 	sshCmd.Flags().BoolVar(&printSSHCLIFlag, "print-cli", false, "Print the CLI one-liner to connect with SSH. (/usr/bin/ssh user@ip -i ...)")
 	sshCmd.Flags().BoolVar(&privateIPFlag, "private", false, "Use private ip to connect to host")
@@ -121,12 +123,15 @@ func instanceCredentialsFromGraph(g *graph.Graph, inst *graph.Resource, keyFlag 
 		return
 	}
 
+	if useAgentFlag {
+		return
+	}
+
 	if keyFlag != "" {
 		keypath = keyFlag
 	} else {
 		keypair, ok := inst.Properties[properties.KeyPair]
 		if !ok {
-			err = fmt.Errorf("no access key set for instance %s", inst.Id())
 			return
 		}
 		keypath = fmt.Sprint(keypair)

--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -39,7 +39,6 @@ import (
 )
 
 var keyPathFlag string
-var useAgentFlag bool
 var printSSHConfigFlag bool
 var printSSHCLIFlag bool
 var privateIPFlag bool
@@ -48,7 +47,6 @@ var disableStrictHostKeyCheckingFlag bool
 func init() {
 	RootCmd.AddCommand(sshCmd)
 	sshCmd.Flags().StringVarP(&keyPathFlag, "identity", "i", "", "Set path or name toward the identity (key file) to use to connect through SSH")
-	sshCmd.Flags().BoolVarP(&useAgentFlag, "agent", "a", false, "Force using SSH agent")
 	sshCmd.Flags().BoolVar(&printSSHConfigFlag, "print-config", false, "Print SSH configuration for ~/.ssh/config file.")
 	sshCmd.Flags().BoolVar(&printSSHCLIFlag, "print-cli", false, "Print the CLI one-liner to connect with SSH. (/usr/bin/ssh user@ip -i ...)")
 	sshCmd.Flags().BoolVar(&privateIPFlag, "private", false, "Use private ip to connect to host")
@@ -120,10 +118,6 @@ var sshCmd = &cobra.Command{
 
 func instanceCredentialsFromGraph(g *graph.Graph, inst *graph.Resource, keyFlag string) (keypath string, ip string, err error) {
 	if ip, err = getIP(inst); err != nil {
-		return
-	}
-
-	if useAgentFlag {
 		return
 	}
 

--- a/commands/ssh_test.go
+++ b/commands/ssh_test.go
@@ -72,7 +72,4 @@ func TestInstanceCredentialsFromName(t *testing.T) {
 	if _, _, err := instanceCredentialsFromGraph(g, inst_3, ""); err == nil {
 		t.Fatal("expected error got none")
 	}
-	if _, _, err := instanceCredentialsFromGraph(g, inst_2, ""); err == nil {
-		t.Fatal("expected error got none")
-	}
 }

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -149,7 +149,10 @@ func (c *Client) localExec() ([]string, bool) {
 		exists = false
 		bin = "ssh"
 	}
-	args := []string{bin, "-i", c.Keypath, fmt.Sprintf("%s@%s", c.User, c.IP)}
+	args := []string{bin, fmt.Sprintf("%s@%s", c.User, c.IP)}
+	if len(c.Keypath) > 0 {
+		args = append(args, "-i", c.Keypath)
+	}
 	if !c.StrictHostKeyChecking {
 		args = append(args, "-o", "StrictHostKeychecking=no")
 	}

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -174,38 +174,41 @@ func DecryptSSHKey(key []byte, password []byte) (gossh.Signer, error) {
 }
 
 func resolveAuthMethod(priv privateKey) (gossh.AuthMethod, error) {
-	var authmethod gossh.AuthMethod
-
 	if len(priv.body) > 0 {
 		signer, err := gossh.ParsePrivateKey(priv.body)
-		if err != nil && strings.Contains(err.Error(), "cannot decode encrypted private keys") {
+		if err != nil {
+			if !strings.Contains(err.Error(), "cannot decode encrypted private keys") {
+				return nil, err
+			}
+
 			fmt.Fprintf(os.Stderr, "This SSH key is encrypted. Please enter passphrase for key '%s':", priv.path)
 			var passphrase []byte
 			passphrase, err = terminal.ReadPassword(int(syscall.Stdin))
 			if err != nil {
 				return nil, err
 			}
+
 			fmt.Fprintln(os.Stderr)
 			signer, err = DecryptSSHKey(priv.body, passphrase)
-
-			authmethod = gossh.PublicKeys(signer)
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		return authmethod, err
-	} else {
-		sshAuthSock := os.Getenv("SSH_AUTH_SOCK")
-		if len(sshAuthSock) == 0 {
-			return nil, fmt.Errorf("No key provided and no SSH_AUTH_SOCK env variable set, unable to resolve auth")
-		}
-
-		agentUnixSock, err := net.Dial("unix", sshAuthSock)
-		if err != nil {
-			return nil, err
-		}
-		authmethod = gossh.PublicKeysCallback(agent.NewClient(agentUnixSock).Signers)
+		return gossh.PublicKeys(signer), err
 	}
 
-	return authmethod, nil
+	sshAuthSock := os.Getenv("SSH_AUTH_SOCK")
+	if len(sshAuthSock) == 0 {
+		return nil, fmt.Errorf("No key provided and no SSH_AUTH_SOCK env variable set, unable to resolve auth")
+	}
+
+	agentUnixSock, err := net.Dial("unix", sshAuthSock)
+	if err != nil {
+		return nil, err
+	}
+
+	return gossh.PublicKeysCallback(agent.NewClient(agentUnixSock).Signers), nil
 }
 
 type privateKey struct {


### PR DESCRIPTION
Thanks for building such a useful tool.

One thing that was missing was the ability to use SSH agent authorization instead of private keys.

This is my attempt to add that functionality.  Basically, if there is no key on an instance it will try to use the SSH_AUTH_SOCK variable to communicate with an agent.  If there is a key on an instance, it will use that key as before.  And, finally, if the `--agent` flag is passed, the agent will be used without looking for a key.

Please let me know what you think.