### PR TITLE
more thoroughly skip host key checks

### DIFF
--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -52,7 +52,7 @@ func init() {
 	sshCmd.Flags().BoolVar(&printSSHConfigFlag, "print-config", false, "Print SSH configuration for ~/.ssh/config file.")
 	sshCmd.Flags().BoolVar(&printSSHCLIFlag, "print-cli", false, "Print the CLI one-liner to connect with SSH. (/usr/bin/ssh user@ip -i ...)")
 	sshCmd.Flags().BoolVar(&privateIPFlag, "private", false, "Use private ip to connect to host")
-	sshCmd.Flags().BoolVar(&disableStrictHostKeyCheckingFlag, "disable-strict-host-keychecking", false, "Disable the remote host key check from ~/.ssh/known_hosts or ~/.awless/known_hosts file")
+	sshCmd.Flags().BoolVarP(&disableStrictHostKeyCheckingFlag, "disable-strict-host-keychecking", "d", false, "Disable the remote host key check from ~/.ssh/known_hosts or ~/.awless/known_hosts file")
 }
 
 var sshCmd = &cobra.Command{

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -160,6 +160,8 @@ func (c *Client) SSHConfigString(hostname string) string {
 	}
 	if !c.StrictHostKeyChecking {
 		extraOpts["StrictHostKeychecking"] = "no"
+		extraOpts["GlobalKnownHostsFile"] = "/dev/null"
+		extraOpts["UserKnownHostsFile"] = "/dev/null"
 	}
 	if c.Port != 22 {
 		extraOpts["Port"] = strconv.Itoa(c.Port)
@@ -203,6 +205,8 @@ func (c *Client) localExec() ([]string, bool) {
 	}
 	if !c.StrictHostKeyChecking {
 		args = append(args, "-o", "StrictHostKeychecking=no")
+		args = append(args, "-o", "GlobalKnownHostsFile=/dev/null")
+		args = append(args, "-o", "UserKnownHostsFile=/dev/null")
 	}
 
 	return args, exists

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -204,8 +204,8 @@ func TestCLIAndConfig(t *testing.T) {
 		},
 		{
 			&Client{Port: 22, IP: "1.2.3.4", User: "ec2-user", StrictHostKeyChecking: false},
-			"/usr/bin/ssh ec2-user@1.2.3.4 -o StrictHostKeychecking=no",
-			"\nHost TestHost\n\tHostname 1.2.3.4\n\tUser ec2-user\n\tStrictHostKeychecking no",
+			"/usr/bin/ssh ec2-user@1.2.3.4 -o StrictHostKeychecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null",
+			"\nHost TestHost\n\tHostname 1.2.3.4\n\tUser ec2-user\n\tGlobalKnownHostsFile /dev/null\n\tStrictHostKeychecking no\n\tUserKnownHostsFile /dev/null",
 		},
 	}
 


### PR DESCRIPTION
Without this change, when the host key changes, you still get a big scary warning, even though the ssh connection succeeds.  This just `/dev/null`s the known hosts file so that nothing is shown.

Also, it adds a short option (`-d`) for skipping the host key check.