### PR TITLE
support passing extra args to ssh

### DIFF
--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -66,7 +66,7 @@ var sshCmd = &cobra.Command{
 	PersistentPostRun: applyHooks(verifyNewVersionHook, onVersionUpgrade),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
+		if len(args) < 1 {
 			return fmt.Errorf("instance required")
 		}
 
@@ -85,6 +85,7 @@ var sshCmd = &cobra.Command{
 		client.SetStrictHostKeyChecking(!disableStrictHostKeyCheckingFlag)
 		client.InteractiveTerminalFunc = console.InteractiveTerminal
 		client.IP = connectionCtx.ip
+		client.ExtraArgs = args[1:len(args)]
 
 		if connectionCtx.user != "" {
 			client, err = client.DialWithUsers(connectionCtx.user)

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -46,6 +46,7 @@ type Client struct {
 	StrictHostKeyChecking   bool
 	InteractiveTerminalFunc func(*gossh.Client) error
 	logger                  *logger.Logger
+	ExtraArgs               []string
 }
 
 func InitClient(keyname string, keyFolders ...string) (*Client, error) {
@@ -204,6 +205,7 @@ func (c *Client) localExec() ([]string, bool) {
 	if !c.StrictHostKeyChecking {
 		args = append(args, "-o", "StrictHostKeychecking=no")
 	}
+	args = append(args, c.ExtraArgs...)
 
 	return args, exists
 }


### PR DESCRIPTION
This adds support for passing extra args straight through to the ssh process, in a similar fashion to [how vagrant does it](https://www.vagrantup.com/docs/cli/ssh.html).  Here are a few use-cases:

* Forwarding your SSH agent: `awless ssh InstanceName -- -A`
* Port forwarding: `awless ssh InstanceName -- -R 8080:localhost:8080`
* Adding debug flags: : `awless ssh InstanceName -- -vvvv`