### PR TITLE
added command to update route53 record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Profile info is now included in execution logs and appended when suggesting revert action (#120)
 - Instance Profiles: List them; attach them to an instance. Ex: `attach instanceprofiles name=...`, `awless ls instanceprofiles`
 - Replace in one command an InstanceProfile on a given instance with the `replace=true` param. Ex: `attach instanceprofile .... replace=true`
+- Update Route53 record set `awless update record`
 
 ### Features
 

--- a/aws/doc/gen_paramsdoc.go
+++ b/aws/doc/gen_paramsdoc.go
@@ -548,4 +548,5 @@ var generatedParamsDoc = map[string]map[string]string{
 		"public": "Specify true to indicate that network interfaces created in the specified subnet should be assigned a public IPv4 address",
 	},
 	"updatetargetgroup": {},
+	"updaterecord":      {},
 }

--- a/aws/doc/gen_paramsdoc.go
+++ b/aws/doc/gen_paramsdoc.go
@@ -512,6 +512,7 @@ var generatedParamsDoc = map[string]map[string]string{
 		"password-reset": "Allows this new password to be used only once by requiring the specified IAM user to set a new password on next sign-in",
 		"username":       "The name of the user whose password you want to update",
 	},
+	"updaterecord": {},
 	"updates3object": {
 		"acl":     "The canned ACL to apply to the object",
 		"bucket":  "",
@@ -548,5 +549,4 @@ var generatedParamsDoc = map[string]map[string]string{
 		"public": "Specify true to indicate that network interfaces created in the specified subnet should be assigned a public IPv4 address",
 	},
 	"updatetargetgroup": {},
-	"updaterecord":      {},
 }

--- a/aws/doc/paramsdoc.go
+++ b/aws/doc/paramsdoc.go
@@ -440,4 +440,12 @@ var manualParamsDoc = map[string]map[string]string{
 		"stickiness":          "Indicates whether sticky sessions (of type load balancer cookies) are enabled. The value is true or false",
 		"stickinessduration":  "The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds)",
 	},
+	"updaterecord": {
+		"zone":    "The ID of the hosted zone that contains the resource record sets that you want to change",
+		"name":    "The name of the domain you want to perform the action on. Enter a fully qualified domain name, for example, www.example.com. You can optionally include a trailing dot",
+		"type":    "The DNS record type. (A | AAAA | CNAME | MX | NAPTR | NS | PTR | SOA | SPF | SRV | TXT)",
+		"value":   "The current or new DNS record value",
+		"ttl":     "The resource record cache time to live (TTL), in seconds",
+		"comment": "Any comments you want to include about a change batch request",
+	},
 }

--- a/aws/driver/driver_funcs.go
+++ b/aws/driver/driver_funcs.go
@@ -2296,74 +2296,12 @@ func (d *S3Driver) Update_Bucket(ctx driver.Context, params map[string]interface
 }
 
 func (d *Route53Driver) Create_Record_DryRun(ctx driver.Context, params map[string]interface{}) (interface{}, error) {
-	if _, ok := params["zone"]; !ok {
-		return nil, errors.New("create record: missing required params 'zone'")
-	}
-
-	if _, ok := params["name"]; !ok {
-		return nil, errors.New("create record: missing required params 'name'")
-	}
-
-	if _, ok := params["type"]; !ok {
-		return nil, errors.New("create record: missing required params 'type'")
-	}
-
-	if _, ok := params["value"]; !ok {
-		return nil, errors.New("create record: missing required params 'value'")
-	}
-
-	if _, ok := params["ttl"]; !ok {
-		return nil, errors.New("create record: missing required params 'ttl'")
-	}
-
-	d.logger.Verbose("params dry run: create record ok")
-	return nil, nil
+	return d.change_Record_DryRun(params, "create")
 }
 
 func (d *Route53Driver) Create_Record(ctx driver.Context, params map[string]interface{}) (interface{}, error) {
-	input := &route53.ChangeResourceRecordSetsInput{}
-	var err error
-	// Required params
-	err = setFieldWithType(params["zone"], input, "HostedZoneId", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	resourceRecord := &route53.ResourceRecord{}
-	change := &route53.Change{ResourceRecordSet: &route53.ResourceRecordSet{ResourceRecords: []*route53.ResourceRecord{resourceRecord}}}
-	input.ChangeBatch = &route53.ChangeBatch{Changes: []*route53.Change{change}}
-	err = setFieldWithType("CREATE", change, "Action", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["name"], change, "ResourceRecordSet.Name", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["type"], change, "ResourceRecordSet.Type", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["ttl"], change, "ResourceRecordSet.TTL", awsint64)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["value"], resourceRecord, "Value", awsstr)
-	if err != nil {
-		return nil, err
-	}
-
-	// Extra params
-	if _, ok := params["comment"]; ok {
-		err = setFieldWithType(params["comment"], input, "ChangeBatch.Comment", awsstr)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	start := time.Now()
-	var output *route53.ChangeResourceRecordSetsOutput
-	output, err = d.ChangeResourceRecordSets(input)
-
+	output, err := d.changeResourceRecordSetsWrapper(params, "CREATE")
 	if err != nil {
 		return nil, fmt.Errorf("create record: %s", err)
 	}
@@ -2373,66 +2311,12 @@ func (d *Route53Driver) Create_Record(ctx driver.Context, params map[string]inte
 }
 
 func (d *Route53Driver) Delete_Record_DryRun(ctx driver.Context, params map[string]interface{}) (interface{}, error) {
-	if _, ok := params["zone"]; !ok {
-		return nil, errors.New("delete record: missing required params 'zone'")
-	}
-
-	if _, ok := params["name"]; !ok {
-		return nil, errors.New("delete record: missing required params 'name'")
-	}
-
-	if _, ok := params["type"]; !ok {
-		return nil, errors.New("delete record: missing required params 'type'")
-	}
-
-	if _, ok := params["value"]; !ok {
-		return nil, errors.New("delete record: missing required params 'value'")
-	}
-
-	if _, ok := params["ttl"]; !ok {
-		return nil, errors.New("delete record: missing required params 'value'")
-	}
-
-	d.logger.Verbose("params dry run: delete record ok")
-	return nil, nil
+	return d.change_Record_DryRun(params, "delete")
 }
 
 func (d *Route53Driver) Delete_Record(ctx driver.Context, params map[string]interface{}) (interface{}, error) {
-	input := &route53.ChangeResourceRecordSetsInput{}
-	var err error
-	// Required params
-	err = setFieldWithType(params["zone"], input, "HostedZoneId", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	resourceRecord := &route53.ResourceRecord{}
-	change := &route53.Change{ResourceRecordSet: &route53.ResourceRecordSet{ResourceRecords: []*route53.ResourceRecord{resourceRecord}}}
-	input.ChangeBatch = &route53.ChangeBatch{Changes: []*route53.Change{change}}
-	err = setFieldWithType("DELETE", change, "Action", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["name"], change, "ResourceRecordSet.Name", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["type"], change, "ResourceRecordSet.Type", awsstr)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["ttl"], change, "ResourceRecordSet.TTL", awsint64)
-	if err != nil {
-		return nil, err
-	}
-	err = setFieldWithType(params["value"], resourceRecord, "Value", awsstr)
-	if err != nil {
-		return nil, err
-	}
-
 	start := time.Now()
-	var output *route53.ChangeResourceRecordSetsOutput
-	output, err = d.ChangeResourceRecordSets(input)
-
+	output, err := d.changeResourceRecordSetsWrapper(params, "DELETE")
 	if err != nil {
 		return nil, fmt.Errorf("delete record: %s", err)
 	}
@@ -2442,31 +2326,46 @@ func (d *Route53Driver) Delete_Record(ctx driver.Context, params map[string]inte
 }
 
 func (d *Route53Driver) Update_Record_DryRun(ctx driver.Context, params map[string]interface{}) (interface{}, error) {
-	if _, ok := params["zone"]; !ok {
-		return nil, errors.New("create record: missing required params 'zone'")
-	}
-
-	if _, ok := params["name"]; !ok {
-		return nil, errors.New("create record: missing required params 'name'")
-	}
-
-	if _, ok := params["type"]; !ok {
-		return nil, errors.New("create record: missing required params 'type'")
-	}
-
-	if _, ok := params["value"]; !ok {
-		return nil, errors.New("create record: missing required params 'value'")
-	}
-
-	if _, ok := params["ttl"]; !ok {
-		return nil, errors.New("create record: missing required params 'ttl'")
-	}
-
-	d.logger.Verbose("params dry run: create record ok")
-	return nil, nil
+	return d.change_Record_DryRun(params, "update")
 }
 
 func (d *Route53Driver) Update_Record(ctx driver.Context, params map[string]interface{}) (interface{}, error) {
+	start := time.Now()
+	output, err := d.changeResourceRecordSetsWrapper(params, "UPSERT")
+	if err != nil {
+		return nil, fmt.Errorf("create record: %s", err)
+	}
+	d.logger.ExtraVerbosef("route53.ChangeResourceRecordSets call took %s", time.Since(start))
+	d.logger.Info("update record done")
+	return aws.StringValue(output.ChangeInfo.Id), nil
+}
+
+func (d *Route53Driver) change_Record_DryRun(params map[string]interface{}, command string) (interface{}, error) {
+	if _, ok := params["zone"]; !ok {
+		return nil, errors.New(command + " record: missing required params 'zone'")
+	}
+
+	if _, ok := params["name"]; !ok {
+		return nil, errors.New(command + " record: missing required params 'name'")
+	}
+
+	if _, ok := params["type"]; !ok {
+		return nil, errors.New(command + " record: missing required params 'type'")
+	}
+
+	if _, ok := params["value"]; !ok {
+		return nil, errors.New(command + " record: missing required params 'value'")
+	}
+
+	if _, ok := params["ttl"]; !ok {
+		return nil, errors.New(command + " record: missing required params 'value'")
+	}
+
+	d.logger.Verbosef("params dry run: %s record ok", command)
+	return nil, nil
+}
+
+func (d *Route53Driver) changeResourceRecordSetsWrapper(params map[string]interface{}, action string) (*route53.ChangeResourceRecordSetsOutput, error) {
 	input := &route53.ChangeResourceRecordSetsInput{}
 	var err error
 	// Required params
@@ -2477,7 +2376,7 @@ func (d *Route53Driver) Update_Record(ctx driver.Context, params map[string]inte
 	resourceRecord := &route53.ResourceRecord{}
 	change := &route53.Change{ResourceRecordSet: &route53.ResourceRecordSet{ResourceRecords: []*route53.ResourceRecord{resourceRecord}}}
 	input.ChangeBatch = &route53.ChangeBatch{Changes: []*route53.Change{change}}
-	err = setFieldWithType("UPSERT", change, "Action", awsstr)
+	err = setFieldWithType(action, change, "Action", awsstr)
 	if err != nil {
 		return nil, err
 	}
@@ -2506,16 +2405,7 @@ func (d *Route53Driver) Update_Record(ctx driver.Context, params map[string]inte
 		}
 	}
 
-	start := time.Now()
-	var output *route53.ChangeResourceRecordSetsOutput
-	output, err = d.ChangeResourceRecordSets(input)
-
-	if err != nil {
-		return nil, fmt.Errorf("create record: %s", err)
-	}
-	d.logger.ExtraVerbosef("route53.ChangeResourceRecordSets call took %s", time.Since(start))
-	d.logger.Info("update record done")
-	return aws.StringValue(output.ChangeInfo.Id), nil
+	return d.ChangeResourceRecordSets(input)
 }
 
 func buildIpPermissionsFromParams(params map[string]interface{}) ([]*ec2.IpPermission, error) {

--- a/aws/driver/gen_drivers.go
+++ b/aws/driver/gen_drivers.go
@@ -1008,6 +1008,12 @@ func (d *Route53Driver) Lookup(lookups ...string) (driverFn driver.DriverFn, err
 		}
 		return d.Delete_Record, nil
 
+	case "updaterecord":
+		if d.dryRun {
+			return d.Update_Record_DryRun, nil
+		}
+		return d.Update_Record, nil
+
 	default:
 		return nil, driver.ErrDriverFnNotFound
 	}

--- a/aws/driver/gen_template_defs.go
+++ b/aws/driver/gen_template_defs.go
@@ -144,6 +144,7 @@ var APIPerTemplateDefName = map[string]string{
 	"deletezone":                "route53",
 	"createrecord":              "route53",
 	"deleterecord":              "route53",
+	"updaterecord":              "route53",
 	"createfunction":            "lambda",
 	"deletefunction":            "lambda",
 	"createalarm":               "cloudwatch",
@@ -1020,6 +1021,13 @@ var AWSTemplatesDefinitions = map[string]template.Definition{
 		RequiredParams: []string{"name", "ttl", "type", "value", "zone"},
 		ExtraParams:    []string{},
 	},
+	"updaterecord": {
+		Action:         "update",
+		Entity:         "record",
+		Api:            "route53",
+		RequiredParams: []string{"name", "ttl", "type", "value", "zone"},
+		ExtraParams:    []string{"comment"},
+	},
 	"createfunction": {
 		Action:         "create",
 		Entity:         "function",
@@ -1279,6 +1287,7 @@ func DriverSupportedActions() map[string][]string {
 	supported["delete"] = append(supported["delete"], "zone")
 	supported["create"] = append(supported["create"], "record")
 	supported["delete"] = append(supported["delete"], "record")
+	supported["update"] = append(supported["update"], "record")
 	supported["create"] = append(supported["create"], "function")
 	supported["delete"] = append(supported["delete"], "function")
 	supported["create"] = append(supported["create"], "alarm")

--- a/aws/driver/gen_template_defs.go
+++ b/aws/driver/gen_template_defs.go
@@ -1026,7 +1026,7 @@ var AWSTemplatesDefinitions = map[string]template.Definition{
 		Entity:         "record",
 		Api:            "route53",
 		RequiredParams: []string{"name", "ttl", "type", "value", "zone"},
-		ExtraParams:    []string{"comment"},
+		ExtraParams:    []string{},
 	},
 	"createfunction": {
 		Action:         "create",

--- a/gen/aws/drivers_definitions.go
+++ b/gen/aws/drivers_definitions.go
@@ -1279,6 +1279,16 @@ var DriversDefs = []driversDef{
 					{TemplateName: "ttl"},
 				},
 			},
+			{
+				Action: "update", Entity: cloud.Record, DryRunUnsupported: true, ManualFuncDefinition: true,
+				RequiredParams: []param{
+					{TemplateName: "zone"},
+					{TemplateName: "name"},
+					{TemplateName: "type"},
+					{TemplateName: "value"},
+					{TemplateName: "ttl"},
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Added command to update route53 record (or create if not exist).

Use case: self-registration of the ec2 instance on route53, with the ability to rewrite existing record.

Implemented by using Route53 API native *UPSERT* action.