### PR TITLE
Stack Events Tail timeout and automatic update cancel

### DIFF
--- a/aws/tailers/stack_event.go
+++ b/aws/tailers/stack_event.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"text/tabwriter"
 	"time"
 
-	"text/tabwriter"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/fatih/color"
@@ -386,7 +384,7 @@ func (s *stackEvent) isFailed() bool {
 }
 
 func (s *stackEventTailer) cancelStackUpdate(cfn *awsservices.Cloudformation) error {
-	inp := &cloudformation.CancelUpdateStackInput{StackName: aws.String(s.stackName)}
+	inp := &cloudformation.CancelUpdateStackInput{StackName: &s.stackName}
 	_, err := cfn.CancelUpdateStack(inp)
 	return err
 }

--- a/commands/tail.go
+++ b/commands/tail.go
@@ -29,6 +29,8 @@ var tailFollowFrequencyFlag time.Duration
 var tailEnableFollowFlag bool
 var tailNumberEventsFlag int
 var stackEventsFilters []string
+var stackEventsTailTimeout time.Duration
+var cancelStackUpdateAfterTimeout bool
 
 func init() {
 	RootCmd.AddCommand(tailCmd)
@@ -47,6 +49,9 @@ func init() {
 			awstailers.StackEventStatusReason,
 			awstailers.StackEventTimestamp,
 			awstailers.StackEventType))
+
+	stackEventsCmd.PersistentFlags().BoolVar(&cancelStackUpdateAfterTimeout, "cancel-on-timeout", false, "Cancel stack update when timeout is reached, use with 'timeout' flag")
+	stackEventsCmd.PersistentFlags().DurationVar(&stackEventsTailTimeout, "timeout", time.Duration(1*time.Hour), "Time to wait for stack update to complete, use with 'follow' flag")
 
 	tailCmd.AddCommand(stackEventsCmd)
 }
@@ -77,6 +82,6 @@ var stackEventsCmd = &cobra.Command{
 			exitOn(fmt.Errorf("expecting stack-name string"))
 		}
 
-		exitOn(awstailers.NewCloudformationEventsTailer(args[0], tailNumberEventsFlag, tailEnableFollowFlag, tailFollowFrequencyFlag, stackEventsFilters).Tail(os.Stdout))
+		exitOn(awstailers.NewCloudformationEventsTailer(args[0], tailNumberEventsFlag, tailEnableFollowFlag, tailFollowFrequencyFlag, stackEventsFilters, stackEventsTailTimeout, cancelStackUpdateAfterTimeout).Tail(os.Stdout))
 	},
 }


### PR DESCRIPTION
* Better errors formatting
* 2 new flags for the `tail stack-events` command: 
   - `timeout` - stop tailing if timeout reached (default `1h`)
   - `cancel-on-timeout` - cancel stack update if timeout reached (default `false`) and keep tailing utill rollback process is completed

Use case:
CloudFormation doesn't provide timeout mechanism for a stack update. For example, deployment of broken ECS task could result in endless retries of ECS task and never leave the `CREATE_IN_PROGRESS` state.

Other solution for this problem could be https://aws.amazon.com/ru/about-aws/whats-new/2017/08/aws-cloudformation-adds-rollback-triggers-feature/

But awless doesn't support rollback-triggers yet and looks like ECS doesn't have the proper CloudWatch metric to monitor.

