### PR TITLE
Add support for AWS_PROFILE environment variable 

### DIFF
--- a/commands/hooks.go
+++ b/commands/hooks.go
@@ -64,6 +64,11 @@ func applyRegionAndProfilePrecedence() error {
 			return err
 		}
 		profileOverridenThrough = "AWS_DEFAULT_PROFILE variable"
+	} else if envProfile := os.Getenv("AWS_PROFILE"); envProfile != "" {
+		if err := config.SetVolatile(config.ProfileConfigKey, envProfile); err != nil {
+			return err
+		}
+		profileOverridenThrough = "AWS_PROFILE variable"
 	}
 
 	profile := config.GetAWSProfile()


### PR DESCRIPTION
This PR adds support for using the AWS_PROFILE environment variable to specify which credential profile to use. This is in line with the AWS CLI and most other SDKs (boto, for example). Use of AWS_DEFAULT_PROFILE is deprecated, and AWS_PROFILE has been preferred for a long while now (see https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html).
Similar to the support in AWS_CLI, though, AWS_PROFILE has a lower precedence than AWS_DEFAULT_PROFILE (for backwards compatibility). So if both are set, then AWS_DEFAULT_PROFILE is honored. 