### PR TITLE
Add linuxbrew to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ For more read our [FAQ](#faq) below (how `awless` compares to other tools, etc.)
 Choose one of the following options:
 
 1. On macOS, use [homebrew](http://brew.sh):  `brew tap wallix/awless; brew install awless`
-2. With `curl` (macOS/Linux), run: `curl https://raw.githubusercontent.com/wallix/awless/master/getawless.sh | bash`
-3. Download the latest `awless` binaries (Windows/Linux/macOS) [from Github](https://github.com/wallix/awless/releases/latest)
-4. If you have Golang already installed, install from the source with: `go get -u github.com/wallix/awless`
+2. On Linux, you can use [linuxbrew](http://linuxbrew.sh/):  `brew tap wallix/awless; brew install awless`
+3. With `curl` (macOS/Linux), run: `curl https://raw.githubusercontent.com/wallix/awless/master/getawless.sh | bash`
+4. Download the latest `awless` binaries (Windows/Linux/macOS) [from Github](https://github.com/wallix/awless/releases/latest)
+5. If you have Golang already installed, install from the source with: `go get -u github.com/wallix/awless`
 
 If you have previously used the AWS CLI or aws-shell, you don't need to configure anything! Your config will be automatically loaded (i.e. ~/.aws/{credentials,config}) and `awless` will prompt for any missing info (more at our [getting started](https://github.com/wallix/awless/wiki/Getting-Started)).
 


### PR DESCRIPTION
You can use linuxbrew to install awless from the same tap as macOS.