### PR TITLE
fixes #254 -- rendering qr code

### DIFF
--- a/aws/spec/mfadevice.go
+++ b/aws/spec/mfadevice.go
@@ -73,7 +73,7 @@ func (cmd *CreateMfadevice) ManualRun(renv env.Running) (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("encode qrcode: %s", err)
 	}
-	qrCodeDisplaySize := 40
+	qrCodeDisplaySize := 43
 	qrcode, err = barcode.Scale(qrcode, qrCodeDisplaySize, qrCodeDisplaySize)
 	if err != nil {
 		return nil, fmt.Errorf("scale qrcode: %s", err)


### PR DESCRIPTION
Changing qrCodeDisplaySize to size 41 or greater fixes this issue. I chose 43 after some trial and error as that gives a proportional border around the rendered QR code similar to what existed before.